### PR TITLE
Add support for environments with SRDF files

### DIFF
--- a/src/hpp/gepetto/manipulation/viewer.py
+++ b/src/hpp/gepetto/manipulation/viewer.py
@@ -46,11 +46,25 @@ class Viewer (Parent):
         self.buildRobotBodies ()
         self.loadUrdfInGUI (RobotType, robotName)
 
-    def loadEnvironmentModel (self, EnvType, envName):
-        self.robot.loadEnvironmentModel (EnvType.packageName, EnvType.urdfName,
-            EnvType.urdfSuffix, EnvType.srdfSuffix, envName + "/")
-        self.buildRobotBodies ()
-        self.loadUrdfInGUI (EnvType, envName)
+    def loadEnvironmentModel (self, EnvType, envName, guiOnly = False):
+        if hasattr (EnvType, 'meshPackageName'):
+            meshPackageName = EnvType.meshPackageName
+        else:
+            meshPackageName = EnvType.packageName
+        # Load robot in viewer
+        if not guiOnly:
+            self.robot.loadEnvironmentModel (EnvType.packageName, EnvType.urdfName,
+                EnvType.urdfSuffix, EnvType.srdfSuffix, envName + "/")
+        rospack = rospkg.RosPack()
+        packagePath = rospack.get_path (EnvType.packageName)
+        meshPackagePath = rospack.get_path (meshPackageName)
+        dataRootDir = os.path.dirname (meshPackagePath) + "/"
+        packagePath += '/urdf/' + EnvType.urdfName + EnvType.urdfSuffix + \
+            '.urdf'
+        self.client.gui.addUrdfObjects (envName, packagePath, meshPackagePath,
+                                        True)
+        self.client.gui.addToGroup (envName, self.sceneName)
+        self.computeObjectPosition ()
 
     def loadObjectModel (self, RobotType, robotName, guiOnly = False):
         if not guiOnly:
@@ -59,6 +73,7 @@ class Viewer (Parent):
                                     RobotType.urdfSuffix, RobotType.srdfSuffix)
         self.buildRobotBodies ()
         self.loadUrdfInGUI (RobotType, robotName)
+        self.computeObjectPosition ()
 
     def buildCompositeRobot (self, robotNames):
         self.robot.buildCompositeRobot (robotNames)

--- a/src/hpp/gepetto/manipulation/viewer.py
+++ b/src/hpp/gepetto/manipulation/viewer.py
@@ -46,6 +46,12 @@ class Viewer (Parent):
         self.buildRobotBodies ()
         self.loadUrdfInGUI (RobotType, robotName)
 
+    def loadEnvironmentModel (self, EnvType, envName):
+        self.robot.loadEnvironmentModel (EnvType.packageName, EnvType.urdfName,
+            EnvType.urdfSuffix, EnvType.srdfSuffix, envName + "/")
+        self.buildRobotBodies ()
+        self.loadUrdfInGUI (EnvType, envName)
+
     def loadObjectModel (self, RobotType, robotName):
         self.robot.loadObjectModel (robotName, RobotType.rootJointType,
                                     RobotType.packageName,

--- a/src/hpp/gepetto/manipulation/viewer.py
+++ b/src/hpp/gepetto/manipulation/viewer.py
@@ -52,11 +52,11 @@ class Viewer (Parent):
         self.buildRobotBodies ()
         self.loadUrdfInGUI (EnvType, envName)
 
-    def loadObjectModel (self, RobotType, robotName):
-        self.robot.loadObjectModel (robotName, RobotType.rootJointType,
-                                    RobotType.packageName,
-                                    RobotType.urdfName, RobotType.urdfSuffix,
-                                    RobotType.srdfSuffix)
+    def loadObjectModel (self, RobotType, robotName, guiOnly = False):
+        if not guiOnly:
+            self.robot.loadObjectModel (robotName, RobotType.rootJointType,
+                                    RobotType.packageName, RobotType.urdfName,
+                                    RobotType.urdfSuffix, RobotType.srdfSuffix)
         self.buildRobotBodies ()
         self.loadUrdfInGUI (RobotType, robotName)
 

--- a/src/hpp/gepetto/viewer.py
+++ b/src/hpp/gepetto/viewer.py
@@ -82,6 +82,9 @@ class Viewer (object):
         self.client.gui.addUrdfObjects (prefix, packagePath, meshPackagePath,
                                         True)
         self.client.gui.addToGroup (prefix, self.sceneName)
+        self.computeObjectPosition ()
+
+    def computeObjectPosition (self):
         # compute object positions
         objects = self.problemSolver.getObstacleNames (True, False)
         for o in objects:

--- a/src/hpp/gepetto/viewer.py
+++ b/src/hpp/gepetto/viewer.py
@@ -69,10 +69,11 @@ class Viewer (object):
                                           self.robot.getJointInnerObjects (j)))
 
     def loadObstacleModel (self, package, filename, prefix,
-                           meshPackageName = None):
+                           meshPackageName = None, guiOnly = False):
         if not meshPackageName:
             meshPackageName = package
-        self.problemSolver.loadObstacleFromUrdf (package, filename, prefix+'/')
+        if not guiOnly:
+            self.problemSolver.loadObstacleFromUrdf (package, filename, prefix+'/')
         rospack = rospkg.RosPack()
         packagePath = rospack.get_path (package)
         meshPackagePath = rospack.get_path (meshPackageName)


### PR DESCRIPTION
## Changes

* Add `loadEnvironmentModel` in Python class `hpp.gepetto.manipulation.Viewer`
* Add parameter `guiOnly`.
* Add `computeObjectPosition` in Python class `hpp.gepetto.Viewer`

## Motivations

* `loadEnvironmentModel`: SRDF files contain definition of contact surfaces for an environment. They are necessary for manipulation problems with static stability.
* `guiOnly`: it is sometimes convenient to load a URDF only in the GUI and not in the HPP server, for instance when the robot is already loaded in HPP.
* `computeObjectPosition`: avoid duplicated code. This method is called by several others.