### PR TITLE
Can change integration time and speed in Path Player

### DIFF
--- a/src/hpp/gepetto/path_player.py
+++ b/src/hpp/gepetto/path_player.py
@@ -22,20 +22,32 @@ import pickle as pk
 ## displays a path by sampling configurations along the path.
 #
 class PathPlayer (object):
-    dt = 0.01
-    def __init__ (self, client, publisher) :
+    def __init__ (self, client, publisher, dt = 0.01, speed = 1) :
         self.client = client
         self.publisher = publisher
+        self.dt = dt
+        self.speed = speed
+
+    def setDt(self,dt):
+      self.dt = dt
+
+    def setSpeed(self,speed) :
+      self.speed = speed
 
     def __call__ (self, pathId) :
         length = self.client.problem.pathLength (pathId)
         t = 0
         while t < length :
+            start = time.time()
             q = self.client.problem.configAtParam (pathId, t)
             self.publisher.robotConfig = q
             self.publisher.publishRobots ()
-            t += self.dt
-            time.sleep (self.dt)
+            t += (self.dt * self.speed)
+            elapsed = time.time() - start
+            if elapsed < self.dt :
+              time.sleep(self.dt-elapsed)
+            else :
+              print("Warning : time step is shorter than computation time for robot geometry ("+str(elapsed)+")")
 
     def toFile(self, pathId, fname):
         length = self.client.problem.pathLength (pathId)


### PR DESCRIPTION
And check the time used for the display and adjust the sleep()

I need it because in the case of a deformable, the time needed by the method Viewer.publishRobot() isn't negligible anymore.