### PR TITLE
Move refresh from publishRobots to __call__ method

### DIFF
--- a/src/hpp/gepetto/path_player.py
+++ b/src/hpp/gepetto/path_player.py
@@ -46,6 +46,7 @@ class PathPlayer (object):
             q = self.client.problem.configAtParam (pathId, t)
             self.publisher.robotConfig = q
             self.publisher.publishRobots ()
+            self.publisher.client.gui.refresh ()
             t += (self.dt * self.speed)
             elapsed = time.time() - start
             if elapsed < self.dt :
@@ -98,10 +99,12 @@ class PathPlayer (object):
                 if play:
                     self.publisher.robotConfig = qs[-1]
                     self.publisher.publishRobots ()
+                    self.publisher.client.gui.refresh ()
             except:
                 qs.append([np.nan] * self.client.robot.getConfigSize())
                 if play:
                     self.publisher.publishRobots ()
+                    self.publisher.client.gui.refresh ()
             t += (self.dt * self.speed)
             elapsed = time.time() - start
             if elapsed < self.dt :
@@ -179,6 +182,7 @@ class PathPlayer (object):
                 start = time.time()
                 self.publisher.robotConfig = q
                 self.publisher.publishRobots ()
+                self.publisher.client.gui.refresh ()
                 elapsed = time.time() - start
                 if elapsed < self.dt :
                   time.sleep(self.dt-elapsed)

--- a/src/hpp/gepetto/viewer.py
+++ b/src/hpp/gepetto/viewer.py
@@ -304,11 +304,11 @@ class Viewer (object):
             pos = self.robot.getLinkPosition (o)
             objectName = prefix + o
             self.client.gui.applyConfiguration (objectName, pos)
-        self.client.gui.refresh ()
 
     def __call__ (self, args):
         self.robotConfig = args
         self.publishRobots ()
+        self.client.gui.refresh ()
 
     ## Start a screen capture
     # \sa gepetto::corbaserver::GraphicalInterface::startCapture


### PR DESCRIPTION
  in class Viewer, in order to make publishRobots method re-implementable in
  derived classes.