### PR TITLE
Modify the way urdf and srdf files are handled

### DIFF
--- a/src/hpp/gepetto/manipulation/viewer.py
+++ b/src/hpp/gepetto/manipulation/viewer.py
@@ -19,6 +19,7 @@
 
 import os
 from hpp.gepetto import Viewer as Parent
+from hpp.gepetto.viewer import _urdfPath, _srdfPath, _urdfSrdfFilenames
 
 ## Simultaneous control to hpp-manipulation-server and gepetto-viewer-server.
 #
@@ -31,50 +32,47 @@ class Viewer (Parent):
         if not self.client.gui.nodeExists(self.compositeRobotName):
             self.client.gui.createGroup (self.compositeRobotName)
             self.client.gui.addToGroup (self.compositeRobotName, self.sceneName)
-        dataRootDir = "" # Ignored for now. Will soon disappear
-        path = self.robot.urdfPath()
+        urdfFilename, srdfFilename = self.robot.urdfSrdfFilenames ()
         name = self.compositeRobotName + '/' + self.robot.robotNames[0]
-        self.client.gui.addURDF (name, path, dataRootDir)
+        self.client.gui.addURDF (name, urdfFilename)
         if self.collisionURDF:
             self.toggleVisual(False)
         #self.client.gui.addToGroup (name, self.compositeRobotName)
 
     def loadRobotModel (self, RobotType, robotName, guiOnly = False, collisionURDF = False, frame = None):
         if not guiOnly:
+            urdfFilename, srdfFilename = _urdfSrdfFilenames (RobotType)
             if frame is None:
                 self.robot.insertRobotModel (robotName, RobotType.rootJointType,
-                                           RobotType.packageName,
-                                           RobotType.urdfName, RobotType.urdfSuffix,
-                                           RobotType.srdfSuffix)
+                                             urdfFilename, srdfFilename)
             else:
-                self.robot.insertRobotModelOnFrame (robotName, frame, RobotType.rootJointType,
-                                           RobotType.packageName,
-                                           RobotType.urdfName, RobotType.urdfSuffix,
-                                           RobotType.srdfSuffix)
+                self.robot.insertRobotModelOnFrame (robotName, frame,
+                                                    RobotType.rootJointType,
+                                                    urdfFilename, srdfFilename)
         self.buildRobotBodies ()
         self.loadUrdfInGUI (RobotType, robotName)
 
     def loadHumanoidModel (self, RobotType, robotName, guiOnly = False):
         if not guiOnly:
+            urdfFilename, srdfFilename = _urdfSrdfFilenames (RobotType)
             self.robot.loadHumanoidModel (robotName, RobotType.rootJointType,
-                                          RobotType.packageName,
-                                          RobotType.modelName, RobotType.urdfSuffix,
-                                          RobotType.srdfSuffix)
+                                          urdfFilename, srdfFilename)
         self.buildRobotBodies ()
         self.loadUrdfInGUI (RobotType, robotName)
 
     def loadEnvironmentModel (self, EnvType, envName, guiOnly = False):
         if not guiOnly:
-            self.robot.loadEnvironmentModel (EnvType.packageName, EnvType.urdfName,
-                EnvType.urdfSuffix, EnvType.srdfSuffix, envName + "/")
+            urdfFilename, srdfFilename = _urdfSrdfFilenames (EnvType)
+            self.robot.loadEnvironmentModel (urdfFilename, srdfFilename,
+                                             envName + "/")
         self.loadUrdfObjectsInGUI (EnvType, envName)
         self.computeObjectPosition ()
 
     def loadObjectModel (self, RobotType, robotName, guiOnly = False):
         if not guiOnly:
+            urdfFilename, srdfFilename = _urdfSrdfFilenames (RobotType)
             self.robot.insertRobotModel (robotName, RobotType.rootJointType,
-                                    RobotType.packageName, RobotType.urdfName,
-                                    RobotType.urdfSuffix, RobotType.srdfSuffix)
+                                         urdfFilename, srdfFilename)
         self.buildRobotBodies ()
         base = "collision_" if self.collisionURDF else ""
         self.loadUrdfInGUI (RobotType, base + robotName)
@@ -86,17 +84,15 @@ class Viewer (Parent):
 
     def loadUrdfInGUI (self, RobotType, robotName):
         # Load robot in viewer
-        dataRootDir = "" # Ignored for now. Will soon disappear
-        path = "package://" + RobotType.packageName + '/urdf/' + RobotType.urdfName + RobotType.urdfSuffix + '.urdf'
+        urdfFilename, srdfFilename = _urdfSrdfFilenames (RobotType)
         nodeName = self.compositeRobotName + "/" + robotName
         if self.collisionURDF:
-            self.client.gui.addUrdfCollision (nodeName, path, dataRootDir)
+            self.client.gui.addUrdfCollision (nodeName, urdfFilename)
         else:
-            self.client.gui.addURDF (nodeName, path, dataRootDir)
+            self.client.gui.addURDF (nodeName, urdfFilename)
 
     def loadUrdfObjectsInGUI (self, RobotType, robotName):
-        dataRootDir = "" # Ignored for now. Will soon disappear
-        path = "package://" + RobotType.packageName + '/urdf/' + RobotType.urdfName + RobotType.urdfSuffix + '.urdf'
-        self.client.gui.addUrdfObjects (robotName, path, dataRootDir,
+        urdfFilename, srdfFilename = _urdfSrdfFilenames (RobotType)
+        self.client.gui.addUrdfObjects (robotName, urdfFilename,
                                         not self.collisionURDF)
         self.client.gui.addToGroup (robotName, self.sceneName)

--- a/src/hpp/gepetto/manipulation/viewer_factory.py
+++ b/src/hpp/gepetto/manipulation/viewer_factory.py
@@ -21,6 +21,7 @@ import os
 import warnings
 from hpp.gepetto import ViewerFactory as Parent
 from hpp.gepetto.manipulation import Viewer
+from hpp.gepetto.viewer import _urdfPath, _srdfPath, _urdfSrdfFilenames
 
 ## Viewer factory for manipulation.Viewer
 #
@@ -38,43 +39,43 @@ class ViewerFactory (Parent):
         self.guiRequest.append ((Viewer.buildRobotBodies, l));
 
     def loadRobotModel (self, RobotType, robotName, guiOnly = False, frame = None):
-        if frame is None:
-            self.robot.insertRobotModel (robotName, RobotType.rootJointType,
-                                       RobotType.packageName,
-                                       RobotType.urdfName, RobotType.urdfSuffix,
-                                       RobotType.srdfSuffix)
-        else:
-            self.robot.insertRobotModelOnFrame (robotName, frame, RobotType.rootJointType,
-                                       RobotType.packageName,
-                                       RobotType.urdfName, RobotType.urdfSuffix,
-                                       RobotType.srdfSuffix)
-        l = locals ();
+        l = locals ().copy ();
+        if not guiOnly:
+            urdfFilename, srdfFilename = _urdfSrdfFilenames (RobotType)
+            if frame is None:
+                self.robot.insertRobotModel (robotName, RobotType.rootJointType,
+                                             urdfFilename, srdfFilename)
+            else:
+                self.robot.insertRobotModelOnFrame (robotName, frame,
+                                                    RobotType.rootJointType,
+                                                    urdfFilename, srdfFilename)
         l ['guiOnly'] = True
         self.guiRequest.append ((Viewer.loadRobotModel, l));
 
     def loadHumanoidModel (self, RobotType, robotName, guiOnly = False):
-        self.robot.loadHumanoidModel (robotName, RobotType.rootJointType,
-                                      RobotType.packageName,
-                                      RobotType.urdfName, RobotType.urdfSuffix,
-                                      RobotType.srdfSuffix)
-        l = locals ();
+        l = locals ().copy ();
+        if not guiOnly:
+            urdfFilename, srdfFilename = _urdfSrdfFilenames (RobotType)
+            self.robot.loadHumanoidModel (robotName, RobotType.rootJointType,
+                                          urdfFilename, srdfFilename)
         l ['guiOnly'] = True
         self.guiRequest.append ((Viewer.loadHumanoidModel, l));
 
     def loadEnvironmentModel (self, EnvType, envName, guiOnly = False):
+        l = locals ().copy ();
         if not guiOnly:
-            self.robot.loadEnvironmentModel (EnvType.packageName, EnvType.urdfName,
-                EnvType.urdfSuffix, EnvType.srdfSuffix, envName + "/")
-        l = locals ();
+            urdfFilename, srdfFilename = _urdfSrdfFilenames (EnvType)
+            self.robot.loadEnvironmentModel (urdfFilename, srdfFilename,
+                                             envName + "/")
         l ['guiOnly'] = True
         self.guiRequest.append ((Viewer.loadEnvironmentModel, l));
 
     def loadObjectModel (self, RobotType, robotName, guiOnly = False):
+        l = locals ().copy ()
         if not guiOnly:
+            urdfFilename, srdfFilename = _urdfSrdfFilenames (RobotType)
             self.robot.insertRobotModel (robotName, RobotType.rootJointType,
-                                    RobotType.packageName, RobotType.urdfName,
-                                    RobotType.urdfSuffix, RobotType.srdfSuffix)
-        l = locals ();
+                                         urdfFilename, srdfFilename)
         l ['guiOnly'] = True
         self.guiRequest.append ((Viewer.loadObjectModel, l));
 

--- a/src/hpp/gepetto/viewer_factory.py
+++ b/src/hpp/gepetto/viewer_factory.py
@@ -20,6 +20,7 @@
 import os.path
 import warnings
 from hpp.gepetto import Viewer
+from hpp.gepetto.viewer import _urdfPath, _srdfPath, _urdfSrdfFilenames
 
 ## Viewer factory
 #
@@ -42,11 +43,16 @@ class ViewerFactory (object):
         l = locals ();
         self.guiRequest.append ((Viewer.addLandmark, l));
 
-    def loadObstacleModel (self, package, filename, prefix,
-                           meshPackageName = None, guiOnly = False):
+    ## Load obstacles from a urdf file
+    #
+    #  \param filename name of the urdf file, may contain "package://"
+    #  \param prefix prefix added to object names in case the same file
+    #         is loaded several times,
+    #  \param guiOnly whether to control only gepetto-viewer-server
+    def loadObstacleModel (self, filename, prefix, guiOnly = False):
+        l = locals ().copy ()
         if not guiOnly:
-            self.problemSolver.loadObstacleFromUrdf (package, filename, prefix+'/')
-        l = locals ();
+            self.problemSolver.loadObstacleFromUrdf (filename, prefix+'/')
         l ['guiOnly'] = True
         self.guiRequest.append ((Viewer.loadObstacleModel, l));
 


### PR DESCRIPTION
  - formerly, urdf and srdf files needed to be in neighbor directories:
    - package://pkg/[urdf|srdf]/.../robot[urdfSuffix|srdfSuffix].[urdf|srdf].
    - Now one filename is given for the urdf file and one filename for the srdf
      file.
Requires https://github.com/humanoid-path-planner/hpp-corbaserver/pull/104, https://github.com/humanoid-path-planner/hpp-manipulation-corba/pull/73, and https://github.com/Gepetto/gepetto-viewer-corba/pull/133.