### PR TITLE
Use ghost viewer from gepetto-viewer

### DIFF
--- a/src/hpp/gepetto/viewer.py
+++ b/src/hpp/gepetto/viewer.py
@@ -20,6 +20,7 @@
 import os.path
 import math
 from hpp.quaternion import Quaternion
+from gepetto.color import Color
 import omniORB.any
 
 def _urdfPath (Type) :
@@ -463,46 +464,3 @@ class Viewer (object):
         self.client.gui.applyConfiguration(n, [ (aabb[0]+aabb[3])/2,(aabb[1]+aabb[4])/2,(aabb[2]+aabb[5])/2,0,0,0,1])
         self.client.gui.setWireFrameMode(n, "WIREFRAME")
         self.client.gui.refresh()
-
-## Helper class 
-class Color(object):
-    # Define some RGBA-normalized color (osg convention)
-    white=[1.0,1.0,1.0,1.0]
-    lightWhite=[1.0,1.0,1.0,0.5]
-    green=[0,1,0,1]
-    lightGreen=[0,1,0,0.5]
-    yellow=[1,1,0,1]
-    lightYellow=[1,1,0,0.5]
-    blue = [0.0, 0.0, 1, 1.0]
-    lightBlue = [0.0, 0.0, 1, 0.5]
-    grey = [0.7,0.7,0.7,1.0]
-    lightGrey= [0.7,0.7,0.7,0.7]
-    red = [1,0.0,0.0,1.0]
-    lightRed = [1,0.0,0.0,0.5]
-    black=[0,0,0,1.0]
-    lightBlack=[0,0,0,0.5]
-    brown = [0.85,0.75,0.15,1.0]
-    lightBrown = [0.85,0.75,0.15,1.0]
-    
-    def __init__(self):
-        self.colors = (
-                [1.0,1.0,1.0,1.0],
-                [1.0,1.0,1.0,0.5],
-                [0,1,0,1],
-                [0,1,0,0.5],
-                [1,1,0,1],
-                [1,1,0,0.5],
-                [0.0, 0.0, 1, 1.0],
-                [0.0, 0.0, 1, 0.5],
-                [0.7,0.7,0.7,1.0],
-                [0.7,0.7,0.7,0.7],
-                [1,0.0,0.0,1.0],
-                [1,0.0,0.0,0.5],
-                [0,0,0,1.0],
-                [0,0,0,0.5],
-                [0.85,0.75,0.15,1.0],
-                [0.85,0.75,0.15,1.0],
-                )
-
-    def __getitem__ (self, i):
-        return self.colors[i]

--- a/src/hpp/gepetto/viewer.py
+++ b/src/hpp/gepetto/viewer.py
@@ -114,15 +114,15 @@ class Viewer (object):
           self.arrowRadius = 0.01
           self.arrowMinSize = 0.05
           self.arrowMaxSize = 1. - self.arrowMinSize
-          if (not ("Vec_Velocity" in self.client.gui.getNodeList())):
+          if self.client.gui.getNodeList() is not None and not ("Vec_Velocity" in self.client.gui.getNodeList()):
             self.client.gui.addArrow("Vec_Velocity",self.arrowRadius,self.arrowMinSize,self.colorVelocity)
             self.client.gui.addToGroup("Vec_Velocity",self.sceneName)
             self.client.gui.setVisibility("Vec_Velocity","OFF")
             self.client.gui.addArrow("Vec_Acceleration",self.arrowRadius,self.arrowMinSize,self.colorAcceleration)
             self.client.gui.addToGroup("Vec_Acceleration",self.sceneName)
             self.client.gui.setVisibility("Vec_Acceleration","OFF")
-            self.amax = omniORB.any.from_any(self.problemSolver.client.problem.getParameter("Kinodynamic/accelerationBound"))
-            self.vmax = omniORB.any.from_any(self.problemSolver.client.problem.getParameter("Kinodynamic/velocityBound"))
+        self.amax = omniORB.any.from_any(self.problemSolver.client.problem.getParameter("Kinodynamic/accelerationBound"))
+        self.vmax = omniORB.any.from_any(self.problemSolver.client.problem.getParameter("Kinodynamic/velocityBound"))
         self.displayCoM = displayCoM
 
     # Set lighting mode OFF for a group of nodes
@@ -130,7 +130,7 @@ class Viewer (object):
     # Some robot models have light produced by their links. This produces a
     # undesired effect in gepetto-gui.
     def _removeLightSources (self, nodes):
-        if not self.removeLightSources:
+        if not self.removeLightSources or nodes is None:
             return
         for n in nodes:
             properties = self.client.gui.getPropertyNames (n)
@@ -424,7 +424,7 @@ class Viewer (object):
                 self.client.gui.applyConfiguration("Vec_Acceleration",qA[0:7])
         if self.displayCoM :
             name = 'sphere_CoM'
-            if not name in self.client.gui.getNodeList():
+            if self.client.gui.getNodeList() is not None and not name in self.client.gui.getNodeList():
                 self.client.gui.addSphere(name,0.01,self.color.red)
                 self.client.gui.setVisibility(name,"ALWAYS_ON_TOP")
                 self.client.gui.addToGroup(name,self.sceneName)

--- a/src/hpp/gepetto/viewer.py
+++ b/src/hpp/gepetto/viewer.py
@@ -22,6 +22,14 @@ import math
 from hpp.quaternion import Quaternion
 from gepetto.color import Color
 import omniORB.any
+from gepetto.corbaserver.client import _GhostGraphicalInterface
+
+
+class _GhostViewerClient:
+
+    def __init__(self):
+        self.gui = _GhostGraphicalInterface()
+
 
 def _urdfPath (Type) :
     return "package://" + Type.packageName + '/urdf/' + Type.urdfName + \

--- a/src/hpp/gepetto/viewer.py
+++ b/src/hpp/gepetto/viewer.py
@@ -93,15 +93,22 @@ class Viewer (object):
     #  \param displayCoM if True, the publish method will also display a small red sphere representing the position of the CoM for the published configuration.
     #
     #  The robot loaded in hppcorbaserver is loaded into gepetto-viewer-server.
-    def __init__ (self, problemSolver, viewerClient = None, collisionURDF = False, displayName = None, displayArrows = False, displayCoM = False):
+    def __init__ (self, problemSolver, viewerClient = None, ghost = False, collisionURDF = False, displayName = None, displayArrows = False, displayCoM = False):
         from gepetto.corbaserver import Client as GuiClient
-
         self.problemSolver = problemSolver
         self.robot = problemSolver.robot
         self.collisionURDF = collisionURDF
         self.color=Color()
         if not viewerClient:
-            viewerClient = GuiClient ()
+            try:
+                viewerClient = GuiClient ()
+            except Exception as e:
+               if ghost:
+                   print("Failed to connect to the viewer.")
+                   print("Check whether gepetto-gui is properly started.")
+                   viewerClient = _GhostViewerClient()
+               else:
+                   raise e
         self.createWindowAndScene (viewerClient, "hpp_")
         self.client = viewerClient
         self.callbacks = []

--- a/src/hpp/gepetto/viewer_factory.py
+++ b/src/hpp/gepetto/viewer_factory.py
@@ -21,6 +21,14 @@ import os.path
 import warnings
 from hpp.gepetto import Viewer
 from hpp.gepetto.viewer import _urdfPath, _srdfPath, _urdfSrdfFilenames
+from gepetto.corbaserver.client import _GhostGraphicalInterface
+
+
+class _GhostViewerClient:
+
+    def __init__(self):
+        self.gui = _GhostGraphicalInterface()
+
 
 ## Viewer factory
 #
@@ -99,13 +107,23 @@ class ViewerFactory (object):
         l = locals ();
         self.guiRequest.append ((Viewer.__call__, l));
 
+
+
     ## Create a client to \c gepetto-viewer-server and send stored commands
     #
     # The arguments of Viewer.__init__ can be passed through kwargs
-    def createViewer (self, ViewerClass = Viewer, viewerClient = None, host = None, *args, **kwargs):
-        if host is not None and viewerClient is None:
+    def createViewer (self, ViewerClass = Viewer, viewerClient = None, ghost = False, host = None, *args, **kwargs):
+        if (host is not None or ghost) and viewerClient is None:
             from gepetto.corbaserver import Client as GuiClient
-            viewerClient = GuiClient (host = host)
+            try:
+                viewerClient = GuiClient (host = host)
+            except Exception as e:
+               if ghost:
+                   print("Failed to connect to the viewer.")
+                   print("Check whether gepetto-gui is properly started.")
+                   viewerClient = _GhostViewerClient()
+               else:
+                   raise e
         v = ViewerClass (self.problemSolver, viewerClient, *args, **kwargs)
         v.removeLightSources = self.removeLightSources
         for call in self.guiRequest:

--- a/src/hpp/gepetto/viewer_factory.py
+++ b/src/hpp/gepetto/viewer_factory.py
@@ -20,14 +20,7 @@
 import os.path
 import warnings
 from hpp.gepetto import Viewer
-from hpp.gepetto.viewer import _urdfPath, _srdfPath, _urdfSrdfFilenames
-from gepetto.corbaserver.client import _GhostGraphicalInterface
-
-
-class _GhostViewerClient:
-
-    def __init__(self):
-        self.gui = _GhostGraphicalInterface()
+from hpp.gepetto.viewer import _urdfPath, _srdfPath, _urdfSrdfFilenames, _GhostViewerClient
 
 
 ## Viewer factory

--- a/src/hpp/gepetto/viewer_factory.py
+++ b/src/hpp/gepetto/viewer_factory.py
@@ -106,7 +106,7 @@ class ViewerFactory (object):
     #
     # The arguments of Viewer.__init__ can be passed through kwargs
     def createViewer (self, ViewerClass = Viewer, viewerClient = None, ghost = False, host = None, *args, **kwargs):
-        if (host is not None or ghost) and viewerClient is None:
+        if host is not None and viewerClient is None:
             from gepetto.corbaserver import Client as GuiClient
             try:
                 viewerClient = GuiClient (host = host)
@@ -117,7 +117,7 @@ class ViewerFactory (object):
                    viewerClient = _GhostViewerClient()
                else:
                    raise e
-        v = ViewerClass (self.problemSolver, viewerClient, *args, **kwargs)
+        v = ViewerClass (self.problemSolver, viewerClient, ghost = ghost, *args, **kwargs)
         v.removeLightSources = self.removeLightSources
         for call in self.guiRequest:
             kwargs = call[1].copy ();


### PR DESCRIPTION
Use the new 'ghost viewer' introduced in https://github.com/Gepetto/gepetto-viewer-corba/pull/140.

Add a 'ghost' argument to` ViewerFactory.createViewer` if True and the creation of a viewer client fail, it use a 'ghost' client : with the same methods as the real client but always return None. 


Also remove the definition of the Color class in viewer.py, this class was duplicated here: https://github.com/Gepetto/gepetto-viewer-corba/blob/master/src/gepetto/corbaserver/__init__.py#L8