### PR TITLE
Fix passing of argument ghost in manipulation.Viewer constructor.

### DIFF
--- a/src/hpp/gepetto/manipulation/viewer.py
+++ b/src/hpp/gepetto/manipulation/viewer.py
@@ -24,9 +24,11 @@ from hpp.gepetto.viewer import _urdfPath, _srdfPath, _urdfSrdfFilenames
 ## Simultaneous control to hpp-manipulation-server and gepetto-viewer-server.
 #
 class Viewer (Parent):
-    def __init__ (self, problemSolver, viewerClient = None, collisionURDF = False, *args, **kwargs) :
+    def __init__ (self, problemSolver, viewerClient = None, ghost = False,
+                  collisionURDF = False, *args, **kwargs) :
         self.compositeRobotName = problemSolver.robot.client.basic.robot.getRobotName()
-        Parent.__init__ (self, problemSolver, viewerClient, collisionURDF, *args, **kwargs)
+        Parent.__init__ (self, problemSolver, viewerClient, ghost,
+                         collisionURDF, *args, **kwargs)
 
     def _initDisplay (self):
         if not self.client.gui.nodeExists(self.compositeRobotName):

--- a/src/hpp/gepetto/viewer.py
+++ b/src/hpp/gepetto/viewer.py
@@ -136,8 +136,12 @@ class Viewer (object):
             self.client.gui.addArrow("Vec_Acceleration",self.arrowRadius,self.arrowMinSize,self.colorAcceleration)
             self.client.gui.addToGroup("Vec_Acceleration",self.sceneName)
             self.client.gui.setVisibility("Vec_Acceleration","OFF")
-        self.amax = omniORB.any.from_any(self.problemSolver.client.problem.getParameter("Kinodynamic/accelerationBound"))
-        self.vmax = omniORB.any.from_any(self.problemSolver.client.problem.getParameter("Kinodynamic/velocityBound"))
+          self.amax = omniORB.any.from_any(self.problemSolver.hppcorba.problem.
+                                           getParameter\
+                                           ("Kinodynamic/accelerationBound"))
+          self.vmax = omniORB.any.from_any(self.problemSolver.hppcorba.problem.
+                                           getParameter\
+                                           ("Kinodynamic/velocityBound"))
         self.displayCoM = displayCoM
 
     # Set lighting mode OFF for a group of nodes


### PR DESCRIPTION
This PR partially fixes https://github.com/humanoid-path-planner/hpp-gepetto-viewer/issues/37.