### PR TITLE
Fix and reorganize display of hpp-python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ ci:
   autoupdate_branch: devel
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.5
+  rev: v0.12.11
   hooks:
   - id: ruff
     args:
@@ -19,13 +19,13 @@ repos:
   - id: toml-sort-fix
     exclude: poetry.lock
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v20.1.8
+  rev: v21.1.0
   hooks:
   - id: clang-format
     args:
     - --style=Google
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
+  rev: v6.0.0
   hooks:
   - id: check-added-large-files
   - id: check-ast

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ option(USE_HPP_PYTHON "Add dependency to hpp-python" OFF)
 
 add_project_dependency("hpp-corbaserver" REQUIRED)
 add_project_dependency("gepetto-viewer")
-if (USE_HPP_PYTHON)
+if(USE_HPP_PYTHON)
   add_project_dependency("hpp-python" REQUIRED)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,8 +52,13 @@ include("${JRL_CMAKE_MODULES}/python.cmake")
 compute_project_args(PROJECT_ARGS LANGUAGES CXX)
 project(${PROJECT_NAME} ${PROJECT_ARGS})
 
+option(USE_HPP_PYTHON "Add dependency to hpp-python" OFF)
+
 add_project_dependency("hpp-corbaserver" REQUIRED)
 add_project_dependency("gepetto-viewer")
+if (USE_HPP_PYTHON)
+  add_project_dependency("hpp-python" REQUIRED)
+endif()
 
 if(NOT FINDPYTHON_ALREADY_CALLED)
   findpython()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,3 +38,8 @@ install_python_files("hpp/gepetto/gui" path_graph.py __init__.py)
 if(gepetto-viewer_FOUND)
   gepetto_gui_pyplugin("hpp/gepetto/gui/path_graph.py")
 endif()
+
+if (USE_HPP_PYTHON)
+  install_python_files("pyhpp" __init__.py)
+  install_python_files("pyhpp/gepetto" __init__.py viewer.py)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,7 @@ if(gepetto-viewer_FOUND)
   gepetto_gui_pyplugin("hpp/gepetto/gui/path_graph.py")
 endif()
 
-if (USE_HPP_PYTHON)
+if(USE_HPP_PYTHON)
   install_python_files("pyhpp" __init__.py)
   install_python_files("pyhpp/gepetto" __init__.py viewer.py)
 endif()

--- a/src/hpp/gepetto/__init__.py
+++ b/src/hpp/gepetto/__init__.py
@@ -1,21 +1,31 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2014 CNRS
-# Author: Florent Lamiraux
-#
-# This file is part of hpp-gepetto-viewer.
-# hpp-gepetto-viewer is free software: you can redistribute it
-# and/or modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation, either version
-# 3 of the License, or (at your option) any later version.
-#
-# hpp-gepetto-viewer is distributed in the hope that it will be
-# useful, but WITHOUT ANY WARRANTY; without even the implied warranty
-# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Lesser Public License for more details.  You should have
-# received a copy of the GNU Lesser General Public License along with
-# hpp-gepetto-viewer.  If not, see
-# <http://www.gnu.org/licenses/>.
+# BSD 2-Clause License
+
+# Copyright (c) 2014-2025, CNRS - INRIA
+
+# Authors: Florent Lamiraux
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from .path_player import PathPlayer  # noqa: F401
 from .viewer import Color, Viewer, displayGripper, displayHandle  # noqa: F401

--- a/src/hpp/gepetto/blender/__init__.py
+++ b/src/hpp/gepetto/blender/__init__.py
@@ -1,20 +1,30 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2014 CNRS
-# Author: Florent Lamiraux
-#
-# This file is part of hpp-gepetto-viewer.
-# hpp-gepetto-viewer is free software: you can redistribute it
-# and/or modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation, either version
-# 3 of the License, or (at your option) any later version.
-#
-# hpp-gepetto-viewer is distributed in the hope that it will be
-# useful, but WITHOUT ANY WARRANTY; without even the implied warranty
-# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Lesser Public License for more details.  You should have
-# received a copy of the GNU Lesser General Public License along with
-# hpp-gepetto-viewer.  If not, see
-# <http://www.gnu.org/licenses/>.
+# BSD 2-Clause License
+
+# Copyright (c) 2014-2025, CNRS - INRIA
+
+# Author: Steve Tonneau
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from . import exportmotion  # noqa: F401

--- a/src/hpp/gepetto/blender/exportmotion.py
+++ b/src/hpp/gepetto/blender/exportmotion.py
@@ -1,21 +1,31 @@
 #!/usr/bin/env python
-#
-# Copyright (c) 2014 CNRS
+
+# BSD 2-Clause License
+
+# Copyright (c) 2014-2025, CNRS - INRIA
+
 # Author: Steve Tonneau
-#
-# This file is part of hpp-gepetto-viewer.
-# hpp-gepetto-viewer is free software: you can redistribute it
-# and/or modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation, either version
-# 3 of the License, or (at your option) any later version.
-#
-# hpp-gepetto-viewer is distributed in the hope that it will be
-# useful, but WITHOUT ANY WARRANTY; without even the implied warranty
-# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Lesser Public License for more details.  You should have
-# received a copy of the GNU Lesser General Public License along with
-# hpp-gepetto-viewer.  If not, see
-# <http://www.gnu.org/licenses/>.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ######################################################

--- a/src/hpp/gepetto/gui/path_graph.py
+++ b/src/hpp/gepetto/gui/path_graph.py
@@ -1,3 +1,30 @@
+# BSD 2-Clause License
+
+# Copyright (c) 2014-2025, CNRS - INRIA
+
+# Author: Joseph Mirabel
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 import hpp_idl
 import numpy as np
 from PythonQt import Qt, QtCore, QtGui

--- a/src/hpp/gepetto/manipulation/__init__.py
+++ b/src/hpp/gepetto/manipulation/__init__.py
@@ -1,21 +1,31 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2014 CNRS
-# Author: Florent Lamiraux
-#
-# This file is part of hpp-gepetto-viewer.
-# hpp-gepetto-viewer is free software: you can redistribute it
-# and/or modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation, either version
-# 3 of the License, or (at your option) any later version.
-#
-# hpp-gepetto-viewer is distributed in the hope that it will be
-# useful, but WITHOUT ANY WARRANTY; without even the implied warranty
-# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Lesser Public License for more details.  You should have
-# received a copy of the GNU Lesser General Public License along with
-# hpp-gepetto-viewer.  If not, see
-# <http://www.gnu.org/licenses/>.
+# BSD 2-Clause License
+
+# Copyright (c) 2014-2025, CNRS - INRIA
+
+# Author: Joseph Mirabel
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from .viewer import Viewer  # noqa: F401
 from .viewer_factory import ViewerFactory  # noqa: F401

--- a/src/hpp/gepetto/manipulation/viewer.py
+++ b/src/hpp/gepetto/manipulation/viewer.py
@@ -1,21 +1,31 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2014 CNRS
+# BSD 2-Clause License
+
+# Copyright (c) 2014-2025, CNRS - INRIA
+
 # Author: Florent Lamiraux
-#
-# This file is part of hpp-gepetto-viewer.
-# hpp-gepetto-viewer is free software: you can redistribute it
-# and/or modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation, either version
-# 3 of the License, or (at your option) any later version.
-#
-# hpp-gepetto-viewer is distributed in the hope that it will be
-# useful, but WITHOUT ANY WARRANTY; without even the implied warranty
-# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Lesser Public License for more details.  You should have
-# received a copy of the GNU Lesser General Public License along with
-# hpp-gepetto-viewer.  If not, see
-# <http://www.gnu.org/licenses/>.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from hpp.gepetto import Viewer as Parent
 from hpp.gepetto.viewer import _urdfSrdfFilenames

--- a/src/hpp/gepetto/manipulation/viewer_factory.py
+++ b/src/hpp/gepetto/manipulation/viewer_factory.py
@@ -1,21 +1,31 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2015 CNRS
-# Author: Florent Lamiraux, Joseph Mirabel
-#
-# This file is part of hpp-gepetto-viewer.
-# hpp-gepetto-viewer is free software: you can redistribute it
-# and/or modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation, either version
-# 3 of the License, or (at your option) any later version.
-#
-# hpp-gepetto-viewer is distributed in the hope that it will be
-# useful, but WITHOUT ANY WARRANTY; without even the implied warranty
-# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Lesser Public License for more details.  You should have
-# received a copy of the GNU Lesser General Public License along with
-# hpp-gepetto-viewer.  If not, see
-# <http://www.gnu.org/licenses/>.
+# BSD 2-Clause License
+
+# Copyright (c) 2014-2025, CNRS - INRIA
+
+# Author: Florent Lamiraux
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from hpp.gepetto import ViewerFactory as Parent
 from hpp.gepetto.manipulation import Viewer

--- a/src/hpp/gepetto/path_player.py
+++ b/src/hpp/gepetto/path_player.py
@@ -1,19 +1,29 @@
-# Copyright (c) 2013, 2014 CNRS
-# Author: Florent Lamiraux
-#
-# This file is part of hpp-gepetto-viewer.
-# hpp-gepetto-viewer is free software: you can redistribute it
-# and/or modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation, either version
-# 3 of the License, or (at your option) any later version.
-#
-# hpp-gepetto-viewer is distributed in the hope that it will be
-# useful, but WITHOUT ANY WARRANTY; without even the implied warranty
-# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Lesser Public License for more details.  You should have
-# received a copy of the GNU Lesser General Public License along with
-# hpp-gepetto-viewer.  If not, see
-# <http://www.gnu.org/licenses/>.
+# BSD 2-Clause License
+
+# Copyright (c) 2014-2025, CNRS - INRIA
+
+# Author: Joseph Mirabel
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import math
 import pickle as pk

--- a/src/hpp/gepetto/types.py
+++ b/src/hpp/gepetto/types.py
@@ -1,21 +1,31 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2025 CNRS
+# BSD 2-Clause License
+
+# Copyright (c) 2014-2025, CNRS - INRIA
+
 # Author: Joseph Mirabel
-#
-# This file is part of hpp-gepetto-viewer.
-# hpp-gepetto-viewer is free software: you can redistribute it
-# and/or modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation, either version
-# 3 of the License, or (at your option) any later version.
-#
-# hpp-gepetto-viewer is distributed in the hope that it will be
-# useful, but WITHOUT ANY WARRANTY; without even the implied warranty
-# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Lesser Public License for more details.  You should have
-# received a copy of the GNU Lesser General Public License along with
-# hpp-gepetto-viewer.  If not, see
-# <http://www.gnu.org/licenses/>.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import typing as T
 

--- a/src/hpp/gepetto/viewer.py
+++ b/src/hpp/gepetto/viewer.py
@@ -1,21 +1,31 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2014 CNRS
+# BSD 2-Clause License
+
+# Copyright (c) 2014-2025, CNRS
+
 # Author: Florent Lamiraux
-#
-# This file is part of hpp-gepetto-viewer.
-# hpp-gepetto-viewer is free software: you can redistribute it
-# and/or modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation, either version
-# 3 of the License, or (at your option) any later version.
-#
-# hpp-gepetto-viewer is distributed in the hope that it will be
-# useful, but WITHOUT ANY WARRANTY; without even the implied warranty
-# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Lesser Public License for more details.  You should have
-# received a copy of the GNU Lesser General Public License along with
-# hpp-gepetto-viewer.  If not, see
-# <http://www.gnu.org/licenses/>.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import math
 import typing as T

--- a/src/hpp/gepetto/viewer_factory.py
+++ b/src/hpp/gepetto/viewer_factory.py
@@ -1,21 +1,31 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2015 CNRS
-# Author: Florent Lamiraux, Joseph Mirabel
-#
-# This file is part of hpp-gepetto-viewer.
-# hpp-gepetto-viewer is free software: you can redistribute it
-# and/or modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation, either version
-# 3 of the License, or (at your option) any later version.
-#
-# hpp-gepetto-viewer is distributed in the hope that it will be
-# useful, but WITHOUT ANY WARRANTY; without even the implied warranty
-# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Lesser Public License for more details.  You should have
-# received a copy of the GNU Lesser General Public License along with
-# hpp-gepetto-viewer.  If not, see
-# <http://www.gnu.org/licenses/>.
+# BSD 2-Clause License
+
+# Copyright (c) 2014-2025, CNRS
+
+# Author: Joseph Mirabel, Florent Lamiraux
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import typing as T
 

--- a/src/pyhpp/gepetto/__init__.py
+++ b/src/pyhpp/gepetto/__init__.py
@@ -1,0 +1,1 @@
+from .viewer import Viewer

--- a/src/pyhpp/gepetto/__init__.py
+++ b/src/pyhpp/gepetto/__init__.py
@@ -1,1 +1,28 @@
+# BSD 2-Clause License
+
+# Copyright (c) 2014-2024, CNRS
+
+# Authors: Florent Lamiraux
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 from .viewer import Viewer

--- a/src/pyhpp/gepetto/__init__.py
+++ b/src/pyhpp/gepetto/__init__.py
@@ -1,1 +1,1 @@
-from .viewer import Viewer
+from .viewer import Viewer as Viewer

--- a/src/pyhpp/gepetto/__init__.py
+++ b/src/pyhpp/gepetto/__init__.py
@@ -1,1 +1,1 @@
-from .viewer import Viewer as Viewer
+from .viewer import Viewer

--- a/src/pyhpp/gepetto/viewer.py
+++ b/src/pyhpp/gepetto/viewer.py
@@ -1,6 +1,6 @@
 # BSD 2-Clause License
 
-# Copyright (c) 2014-2024, CNRS - INRIA
+# Copyright (c) 2014-2025, CNRS - INRIA
 
 # Authors: Gabriele Buondono, Florent Lamiraux, Joris Vaillant
 

--- a/src/pyhpp/gepetto/viewer.py
+++ b/src/pyhpp/gepetto/viewer.py
@@ -1,13 +1,23 @@
-import numpy
 from math import pi
+import numpy as np
 from gepetto.corbaserver import Client
 from gepetto import Error as GepettoError
-from pinocchio import forwardKinematics, updateGeometryPlacements
+from pinocchio import forwardKinematics, updateGeometryPlacements, SE3
 from eigenpy import Quaternion
-from pyhpp.manipulation import urdf
+from pyhpp.pinocchio import urdf
+from pyhpp.core import path
+
+import time
 
 class Viewer:
 
+    def displayPath(self, path):
+        for i in range(path.numberPaths()):  
+            for t in np.linspace(0,path.pathAtRank(i).length(),1000):
+                q, success = path.pathAtRank(i).eval(t)
+                if success:
+                    self.applyConfiguration(q)
+                    time.sleep(0.001)  
 
     def createWindowAndScene(self, name):
         self.windowName = "scene_hpp_" + name
@@ -16,6 +26,11 @@ class Viewer:
         except GepettoError:
             self.windowId = self.client.gui.createWindow(self.windowName)
         self.sceneName = self.windowName
+
+    def addURDFObstacleToScene(self, filename, prefix):
+        urdf.loadModel(self.robot, 0, prefix, "anchor", filename, "", SE3.Identity());
+        self.client.gui.addUrdfObjects(prefix, filename, True)
+        self.client.gui.addToGroup(prefix, self.sceneName)
 
     def addURDFToScene(self, frameIndex, prefix, rootType, urdfFilename, srdfFilename, pose):
         urdf.loadModel(self.robot, frameIndex, prefix, rootType, urdfFilename, srdfFilename, pose)
@@ -40,4 +55,3 @@ class Viewer:
             pose1 = list(pose.translation) + list(Quaternion(pose.rotation).coeffs())
             self.client.gui.applyConfiguration(o, pose1)
         self.client.gui.refresh()
-

--- a/src/pyhpp/gepetto/viewer.py
+++ b/src/pyhpp/gepetto/viewer.py
@@ -28,9 +28,8 @@
 import warnings
 
 import numpy as np
-from numpy.linalg import norm
-
 import pinocchio as pin
+from numpy.linalg import norm
 from pinocchio.utils import npToTuple
 from pinocchio.visualize import BaseVisualizer
 
@@ -56,17 +55,18 @@ class Viewer(BaseVisualizer):
 
     def playPath(self, path, speed=0.01, nbPoints=300):
         for t in np.linspace(0, path.length(), nbPoints):
-                q, success = path.eval(t)
-                if success:
-                    self.display(q)
-                    time.sleep(speed)
+            q, success = path.eval(t)
+            if success:
+                self.display(q)
+                time.sleep(speed)
 
-    def getViewerNodeName(self, geometry_object, geometry_type, create_groups = False):
+    def getViewerNodeName(self, geometry_object, geometry_type, create_groups=False):
         """Return the name of the geometry object inside the viewer"""
-        type_str = "collision" if geometry_type == pin.GeometryType.COLLISION \
-            else "visual"
+        type_str = (
+            "collision" if geometry_type == pin.GeometryType.COLLISION else "visual"
+        )
         names = geometry_object.name.split("/")
-        assert(len(names) >= 2)
+        assert len(names) >= 2
         names = names[:-1] + [type_str] + names[-1:]
         res = self.viewerRootNodeName
         for n in names:
@@ -89,8 +89,8 @@ class Viewer(BaseVisualizer):
         loadModel=True,
     ):
         """Init GepettoViewer by loading the gui and creating a window."""
-        windowName="hpp"
-        sceneName=self.robot.name()
+        windowName = "hpp"
+        sceneName = self.robot.name()
 
         try:
             import gepetto.corbaserver

--- a/src/pyhpp/gepetto/viewer.py
+++ b/src/pyhpp/gepetto/viewer.py
@@ -48,7 +48,7 @@ class Viewer(BaseVisualizer):
     def __init__(self, robot):
         self.robot = robot
         self.viewerRootNodeName = self.robot.name()
-        super().__init__(robot.model(), robot.geomModel(), robot.geomModel())
+        super().__init__(robot.model(), robot.geomModel(), robot.visualModel())
         self.initViewer()
 
     def __call__(self, q):

--- a/src/pyhpp/gepetto/viewer.py
+++ b/src/pyhpp/gepetto/viewer.py
@@ -51,6 +51,16 @@ class Viewer(BaseVisualizer):
         super().__init__(robot.model(), robot.geomModel(), robot.geomModel())
         self.initViewer()
 
+    def __call__(self, q):
+        self.display(q)
+
+    def playPath(self, path, speed=0.01, nbPoints=300):
+        for t in np.linspace(0, path.length(), nbPoints):
+                q, success = path.eval(t)
+                if success:
+                    self.display(q)
+                    time.sleep(speed)
+
     def getViewerNodeName(self, geometry_object, geometry_type, create_groups = False):
         """Return the name of the geometry object inside the viewer"""
         type_str = "collision" if geometry_type == pin.GeometryType.COLLISION \

--- a/src/pyhpp/gepetto/viewer.py
+++ b/src/pyhpp/gepetto/viewer.py
@@ -5,19 +5,18 @@ from gepetto import Error as GepettoError
 from pinocchio import forwardKinematics, updateGeometryPlacements, SE3
 from eigenpy import Quaternion
 from pyhpp.pinocchio import urdf
-from pyhpp.core import path
 
 import time
 
 class Viewer:
 
-    def displayPath(self, path):
+    def displayPath(self, path, speed=0.01, nbPoints=300):
         for i in range(path.numberPaths()):  
-            for t in np.linspace(0,path.pathAtRank(i).length(),1000):
+            for t in np.linspace(0,path.pathAtRank(i).length(),nbPoints):
                 q, success = path.pathAtRank(i).eval(t)
                 if success:
                     self.applyConfiguration(q)
-                    time.sleep(0.001)  
+                    time.sleep(speed)  
 
     def createWindowAndScene(self, name):
         self.windowName = "scene_hpp_" + name

--- a/src/pyhpp/gepetto/viewer.py
+++ b/src/pyhpp/gepetto/viewer.py
@@ -1,0 +1,43 @@
+import numpy
+from math import pi
+from gepetto.corbaserver import Client
+from gepetto import Error as GepettoError
+from pinocchio import forwardKinematics, updateGeometryPlacements
+from eigenpy import Quaternion
+from pyhpp.manipulation import urdf
+
+class Viewer:
+
+
+    def createWindowAndScene(self, name):
+        self.windowName = "scene_hpp_" + name
+        try:
+            self.windowId = self.client.gui.getWindowID(self.windowName)
+        except GepettoError:
+            self.windowId = self.client.gui.createWindow(self.windowName)
+        self.sceneName = self.windowName
+
+    def addURDFToScene(self, frameIndex, prefix, rootType, urdfFilename, srdfFilename, pose):
+        urdf.loadModel(self.robot, frameIndex, prefix, rootType, urdfFilename, srdfFilename, pose)
+        self.client.gui.addURDF(prefix, urdfFilename)
+        self.client.gui.addToGroup(prefix, self.sceneName)
+
+    def __init__(self, name, robot):
+        self.robot = robot
+        self.client = Client()
+        self.createWindowAndScene(name)
+
+    def applyConfiguration(self, q):
+        model = self.robot.model()
+        gmodel = self.robot.geomModel()
+        data = model.createData()
+        gData = gmodel.createData()
+        objects = [gmodel.geometryObjects[i].name for i in range(gmodel.ngeoms)]
+        forwardKinematics(model, data, q)
+        updateGeometryPlacements(model, data, gmodel, gData)
+        for i, o in enumerate(objects):
+            pose = gData.oMg[i]
+            pose1 = list(pose.translation) + list(Quaternion(pose.rotation).coeffs())
+            self.client.gui.applyConfiguration(o, pose1)
+        self.client.gui.refresh()
+

--- a/src/pyhpp/gepetto/viewer.py
+++ b/src/pyhpp/gepetto/viewer.py
@@ -1,73 +1,360 @@
-import time
+# BSD 2-Clause License
+
+# Copyright (c) 2014-2024, CNRS - INRIA
+
+# Authors: Gabriele Buondono, Florent Lamiraux, Joris Vaillant
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import warnings
 
 import numpy as np
-from eigenpy import Quaternion
-from gepetto import Error as GepettoError
-from gepetto.corbaserver import Client
-from pinocchio import SE3, forwardKinematics, updateFramePlacements
+from numpy.linalg import norm
 
-from pyhpp.pinocchio import urdf
-import pinocchio.pinocchio_pywrap_default
-BODY = pinocchio.pinocchio_pywrap_default.FrameType(8)
+import pinocchio as pin
+from pinocchio.utils import npToTuple
+from pinocchio.visualize import BaseVisualizer
 
-class Viewer:
-    def displayPath(self, path, speed=0.01, nbPoints=300):
-        for i in range(path.numberPaths()):
-            for t in np.linspace(0, path.pathAtRank(i).length(), nbPoints):
-                q, success = path.pathAtRank(i).eval(t)
-                if success:
-                    self.applyConfiguration(q)
-                    time.sleep(speed)
+try:
+    import hppfcl
 
-    def createWindowAndScene(self, name):
-        self.windowName = "scene_hpp_" + name
-        try:
-            self.windowId = self.client.gui.getWindowID(self.windowName)
-        except GepettoError:
-            self.windowId = self.client.gui.createWindow(self.windowName)
-        self.sceneName = self.windowName
+    WITH_HPP_FCL_BINDINGS = True
+except:  # noqa: E722
+    WITH_HPP_FCL_BINDINGS = False
 
-    def addURDFObstacleToScene(self, filename, prefix):
-        urdf.loadModel(self.robot, 0, prefix, "anchor", filename, "", SE3.Identity())
-        self.client.gui.addUrdfObjects(self.sceneName + "/" + prefix, filename, True)
-        self._recomputeObjects()
-        #self.client.gui.addToGroup(prefix, self.sceneName)
 
-    def addURDFToScene(
-        self, frameIndex, prefix, rootType, urdfFilename, srdfFilename, pose
-    ):
-        urdf.loadModel(
-            self.robot, frameIndex, prefix, rootType, urdfFilename, srdfFilename, pose
-        )
-        self.client.gui.addURDF(self.sceneName + "/" + prefix, urdfFilename)
-        self._recomputeObjects()
-        #self.client.gui.addToGroup(prefix, self.sceneName)
+class Viewer(BaseVisualizer):
+    """An HPP display using Gepetto Viewer"""
 
-    def __init__(self, name, robot):
+    def __init__(self, robot):
         self.robot = robot
-        self.client = Client()
-        self.createWindowAndScene(name)
-        self.hppObjectNames = list()
-        self.guiObjectNames = list()
-        self.objectIndices = list()
+        self.viewerRootNodeName = self.robot.name()
+        super().__init__(robot.model(), robot.geomModel(), robot.geomModel())
+        self.initViewer()
 
-    def applyConfiguration(self, q):
-        model = self.robot.model()
-        data = model.createData()
-        forwardKinematics(model, data, q)
-        updateFramePlacements(model, data)
-        for i, hppObj, guiObj in zip(self.objectIndices, self.hppObjectNames, self.guiObjectNames):
-            pose = data.oMf[i]
-            pose1 = list(pose.translation) + list(Quaternion(pose.rotation).coeffs())
-            self.client.gui.applyConfiguration(guiObj, pose1)
-        self.client.gui.refresh()
+    def getViewerNodeName(self, geometry_object, geometry_type, create_groups = False):
+        """Return the name of the geometry object inside the viewer"""
+        type_str = "collision" if geometry_type == pin.GeometryType.COLLISION \
+            else "visual"
+        names = geometry_object.name.split("/")
+        assert(len(names) >= 2)
+        names = names[:-1] + [type_str] + names[-1:]
+        res = self.viewerRootNodeName
+        for n in names:
+            res += "/" + n
+        if create_groups:
+            group_name = self.viewerRootNodeName
+            if not self.client.gui.nodeExists(group_name):
+                self.client.gui.createGroup(group_name)
+            for n in names[:-1]:
+                node_name = group_name + "/" + n
+                if not self.client.gui.nodeExists(node_name):
+                    self.client.gui.createGroup(node_name)
+                    self.client.gui.addToGroup(node_name, group_name)
+                group_name = node_name
+        return res
 
-    def _recomputeObjects(self):
-        self.hppObjectNames = list()
-        self.guiObjectNames = list()
-        model = self.robot.model()
-        for f in model.frames:
-            if model.existFrame(f.name, BODY):
-                self.hppObjectNames.append(f.name)
-                self.guiObjectNames.append(self.sceneName + "/" + f.name)
-                self.objectIndices.append(model.getFrameId(f.name))
+    def initViewer(
+        self,
+        viewer=None,
+        loadModel=True,
+    ):
+        """Init GepettoViewer by loading the gui and creating a window."""
+        windowName="hpp"
+        sceneName=self.robot.name()
+
+        try:
+            import gepetto.corbaserver
+        except ImportError:
+            import warnings
+
+            msg = (
+                "Error while importing the viewer client.\n"
+                "Check whether gepetto-gui is properly installed"
+            )
+            warnings.warn(msg, category=UserWarning, stacklevel=2)
+
+        try:
+            self.client = gepetto.corbaserver.Client() if viewer is None else viewer
+            gui = self.client.gui
+
+            # Create window
+            window_l = gui.getWindowList()
+            if windowName not in window_l:
+                self.windowID = self.client.gui.createWindow(windowName)
+            else:
+                self.windowID = self.client.gui.getWindowID(windowName)
+
+            # Create scene if needed
+            scene_l = gui.getSceneList()
+            if sceneName not in scene_l:
+                gui.createScene(sceneName)
+            self.sceneName = sceneName
+            gui.addSceneToWindow(sceneName, self.windowID)
+
+            if loadModel:
+                self.loadViewerModel()
+        except:  # noqa: E722
+            import warnings
+
+            msg = (
+                "Error while starting the viewer client.\n"
+                "Check whether gepetto-viewer is properly started"
+            )
+            warnings.warn(msg, category=UserWarning, stacklevel=2)
+
+    def loadPrimitive(self, meshName, geometry_object):
+        gui = self.client.gui
+
+        meshColor = geometry_object.meshColor
+
+        geom = geometry_object.geometry
+        if isinstance(geom, hppfcl.Capsule):
+            return gui.addCapsule(
+                meshName, geom.radius, 2.0 * geom.halfLength, npToTuple(meshColor)
+            )
+        elif isinstance(geom, hppfcl.Cylinder):
+            return gui.addCylinder(
+                meshName, geom.radius, 2.0 * geom.halfLength, npToTuple(meshColor)
+            )
+        elif isinstance(geom, hppfcl.Box):
+            w, h, d = npToTuple(2.0 * geom.halfSide)
+            return gui.addBox(meshName, w, h, d, npToTuple(meshColor))
+        elif isinstance(geom, hppfcl.Sphere):
+            return gui.addSphere(meshName, geom.radius, npToTuple(meshColor))
+        elif isinstance(geom, hppfcl.Cone):
+            return gui.addCone(
+                meshName, geom.radius, 2.0 * geom.halfLength, npToTuple(meshColor)
+            )
+        elif isinstance(geom, hppfcl.Plane) or isinstance(geom, hppfcl.Halfspace):
+            res = gui.createGroup(meshName)
+            if not res:
+                return False
+            planeName = meshName + "/plane"
+            res = gui.addFloor(planeName)
+            if not res:
+                return False
+            normal = geom.n
+            rot = pin.Quaternion.FromTwoVectors(normal, pin.ZAxis)
+            alpha = geom.d / norm(normal, 2) ** 2
+            trans = alpha * normal
+            plane_offset = pin.SE3(rot, trans)
+            gui.applyConfiguration(planeName, pin.SE3ToXYZQUATtuple(plane_offset))
+        elif isinstance(geom, hppfcl.Convex):
+            pts = [
+                npToTuple(geom.points(geom.polygons(f)[i]))
+                for f in range(geom.num_polygons)
+                for i in range(3)
+            ]
+            gui.addCurve(meshName, pts, npToTuple(meshColor))
+            gui.setCurveMode(meshName, "TRIANGLES")
+            gui.setLightingMode(meshName, "ON")
+            gui.setBoolProperty(meshName, "BackfaceDrawing", True)
+            return True
+        elif isinstance(geom, hppfcl.ConvexBase):
+            pts = [npToTuple(geom.points(i)) for i in range(geom.num_points)]
+            gui.addCurve(meshName, pts, npToTuple(meshColor))
+            gui.setCurveMode(meshName, "POINTS")
+            gui.setLightingMode(meshName, "OFF")
+            return True
+        else:
+            msg = f"Unsupported geometry type for {geometry_object.name} ({type(geom)})"
+            warnings.warn(msg, category=UserWarning, stacklevel=2)
+            return False
+
+    def loadViewerGeometryObject(self, geometry_object, geometry_type):
+        """Load a single geometry object"""
+
+        gui = self.client.gui
+
+        meshName = self.getViewerNodeName(geometry_object, geometry_type, True)
+        meshPath = geometry_object.meshPath
+        meshTexturePath = geometry_object.meshTexturePath
+        meshScale = geometry_object.meshScale
+        meshColor = geometry_object.meshColor
+
+        try:
+            if WITH_HPP_FCL_BINDINGS and isinstance(
+                geometry_object.geometry, hppfcl.ShapeBase
+            ):
+                success = self.loadPrimitive(meshName, geometry_object)
+            else:
+                if meshName == "":
+                    msg = (
+                        "Display of geometric primitives is supported only if "
+                        "pinocchio is build with HPP-FCL bindings."
+                    )
+                    warnings.warn(msg, category=UserWarning, stacklevel=2)
+                    return
+                success = gui.addMesh(meshName, meshPath)
+            if not success:
+                return
+        except Exception as e:
+            msg = (
+                "Error while loading geometry object: "
+                f"{geometry_object.name}\nError message:\n{e}"
+            )
+            warnings.warn(msg, category=UserWarning, stacklevel=2)
+            return
+
+        gui.setScale(meshName, npToTuple(meshScale))
+        if geometry_object.overrideMaterial:
+            gui.setColor(meshName, npToTuple(meshColor))
+            if meshTexturePath != "":
+                gui.setTexture(meshName, meshTexturePath)
+
+    def loadViewerModel(self):
+        """Create the scene displaying the robot meshes in gepetto-viewer"""
+
+        # Start a new "scene" in this window, named "world", with just a floor.
+        gui = self.client.gui
+
+        if not gui.nodeExists(self.viewerRootNodeName):
+            gui.createGroup(self.viewerRootNodeName)
+
+        # iterate over visuals and create the meshes in the viewer
+        if self.collision_model is not None:
+            for collision in self.collision_model.geometryObjects:
+                self.loadViewerGeometryObject(collision, pin.GeometryType.COLLISION)
+        # Display collision if we have them and there is no visual
+        self.displayCollisions(
+            self.collision_model is not None and self.visual_model is None
+        )
+
+        if self.visual_model is not None:
+            for visual in self.visual_model.geometryObjects:
+                self.loadViewerGeometryObject(visual, pin.GeometryType.VISUAL)
+        self.displayVisuals(self.visual_model is not None)
+
+        # Finally, refresh the layout to obtain your first rendering.
+        gui.refresh()
+
+    def display(self, q=None):
+        """
+        Display the robot at configuration q in the viewer by placing all the bodies.
+        """
+        gui = self.client.gui
+        # Update the robot kinematics and geometry.
+        if q is not None:
+            pin.forwardKinematics(self.model, self.data, q)
+
+        if self.display_collisions:
+            pin.updateGeometryPlacements(
+                self.model, self.data, self.collision_model, self.collision_data
+            )
+            gui.applyConfigurations(
+                [
+                    self.getViewerNodeName(collision, pin.GeometryType.COLLISION)
+                    for collision in self.collision_model.geometryObjects
+                ],
+                [
+                    pin.SE3ToXYZQUATtuple(
+                        self.collision_data.oMg[
+                            self.collision_model.getGeometryId(collision.name)
+                        ]
+                    )
+                    for collision in self.collision_model.geometryObjects
+                ],
+            )
+
+        if self.display_visuals:
+            pin.updateGeometryPlacements(
+                self.model, self.data, self.visual_model, self.visual_data
+            )
+            gui.applyConfigurations(
+                [
+                    self.getViewerNodeName(visual, pin.GeometryType.VISUAL)
+                    for visual in self.visual_model.geometryObjects
+                ],
+                [
+                    pin.SE3ToXYZQUATtuple(
+                        self.visual_data.oMg[
+                            self.visual_model.getGeometryId(visual.name)
+                        ]
+                    )
+                    for visual in self.visual_model.geometryObjects
+                ],
+            )
+
+        gui.refresh()
+
+    def displayCollisions(self, visibility):
+        """Set whether to display collision objects or not"""
+        gui = self.client.gui
+        self.display_collisions = visibility
+        if self.collision_model is None:
+            return
+
+        if visibility:
+            visibility_mode = "ON"
+        else:
+            visibility_mode = "OFF"
+
+        for collision in self.collision_model.geometryObjects:
+            nodeName = self.getViewerNodeName(collision, pin.GeometryType.COLLISION)
+            gui.setVisibility(nodeName, visibility_mode)
+
+    def displayVisuals(self, visibility):
+        """Set whether to display visual objects or not"""
+        gui = self.client.gui
+        self.display_visuals = visibility
+        if self.visual_model is None:
+            return
+
+        if visibility:
+            visibility_mode = "ON"
+        else:
+            visibility_mode = "OFF"
+
+        for visual in self.visual_model.geometryObjects:
+            nodeName = self.getViewerNodeName(visual, pin.GeometryType.VISUAL)
+            gui.setVisibility(nodeName, visibility_mode)
+
+    def setBackgroundColor(self):
+        raise NotImplementedError()
+
+    def setCameraTarget(self, target):
+        raise NotImplementedError()
+
+    def setCameraPosition(self, position: np.ndarray):
+        raise NotImplementedError()
+
+    def setCameraZoom(self, zoom: float):
+        raise NotImplementedError()
+
+    def setCameraPose(self, pose: np.ndarray):
+        raise NotImplementedError()
+
+    def captureImage(self, w=None, h=None):
+        raise NotImplementedError()
+
+    def disableCameraControl(self):
+        raise NotImplementedError()
+
+    def enableCameraControl(self):
+        raise NotImplementedError()
+
+    def drawFrameVelocities(self, *args, **kwargs):
+        raise NotImplementedError()
+
+
+__all__ = ["Viewer"]

--- a/src/pyhpp/gepetto/viewer.py
+++ b/src/pyhpp/gepetto/viewer.py
@@ -1,22 +1,22 @@
-from math import pi
-import numpy as np
-from gepetto.corbaserver import Client
-from gepetto import Error as GepettoError
-from pinocchio import forwardKinematics, updateGeometryPlacements, SE3
-from eigenpy import Quaternion
-from pyhpp.pinocchio import urdf
-
 import time
 
-class Viewer:
+import numpy as np
+from eigenpy import Quaternion
+from gepetto import Error as GepettoError
+from gepetto.corbaserver import Client
+from pinocchio import SE3, forwardKinematics, updateGeometryPlacements
 
+from pyhpp.pinocchio import urdf
+
+
+class Viewer:
     def displayPath(self, path, speed=0.01, nbPoints=300):
-        for i in range(path.numberPaths()):  
-            for t in np.linspace(0,path.pathAtRank(i).length(),nbPoints):
+        for i in range(path.numberPaths()):
+            for t in np.linspace(0, path.pathAtRank(i).length(), nbPoints):
                 q, success = path.pathAtRank(i).eval(t)
                 if success:
                     self.applyConfiguration(q)
-                    time.sleep(speed)  
+                    time.sleep(speed)
 
     def createWindowAndScene(self, name):
         self.windowName = "scene_hpp_" + name
@@ -27,12 +27,16 @@ class Viewer:
         self.sceneName = self.windowName
 
     def addURDFObstacleToScene(self, filename, prefix):
-        urdf.loadModel(self.robot, 0, prefix, "anchor", filename, "", SE3.Identity());
+        urdf.loadModel(self.robot, 0, prefix, "anchor", filename, "", SE3.Identity())
         self.client.gui.addUrdfObjects(prefix, filename, True)
         self.client.gui.addToGroup(prefix, self.sceneName)
 
-    def addURDFToScene(self, frameIndex, prefix, rootType, urdfFilename, srdfFilename, pose):
-        urdf.loadModel(self.robot, frameIndex, prefix, rootType, urdfFilename, srdfFilename, pose)
+    def addURDFToScene(
+        self, frameIndex, prefix, rootType, urdfFilename, srdfFilename, pose
+    ):
+        urdf.loadModel(
+            self.robot, frameIndex, prefix, rootType, urdfFilename, srdfFilename, pose
+        )
         self.client.gui.addURDF(prefix, urdfFilename)
         self.client.gui.addToGroup(prefix, self.sceneName)
 


### PR DESCRIPTION
Displaying robots and objects built with `hpp-python` did not work correctly. This pull request rewrites the connection  between `gepetto-gui` and `hpp-python` taking inspiration for GepettoVisualizer class in pinocchio.

It also integrates changes proposed in https://github.com/humanoid-path-planner/hpp-gepetto-viewer/pull/127
with some renamings:
  - applyConfiguration -> display,
  - displayPath -> playPath.

Requires https://github.com/humanoid-path-planner/hpp-python/pull/55.